### PR TITLE
using Object.prototype.hasOwnProperty.call instead of <object>.hasOwnProperty to prevent prototype pollution vulnerability

### DIFF
--- a/src/jsoning.js
+++ b/src/jsoning.js
@@ -229,7 +229,7 @@ class Jsoning {
 
 		// see if value exists
 		let db = JSON.parse(fs.readFileSync(resolve(__dirname, this.database), 'utf-8'));
-		if (Object.prototype.hasOwnProperty(db, key)) {
+		if (Object.prototype.hasOwnProperty.call(db, key)) {
 			// key exists
 			let value = db[key];
 			if (typeof value !== 'number' || value === '') {

--- a/src/jsoning.js
+++ b/src/jsoning.js
@@ -119,7 +119,7 @@ class Jsoning {
 		let db = JSON.parse(
 			fs.readFileSync(resolve(__dirname, this.database), 'utf-8')
 		);
-		if (db.hasOwnProperty(key)) {
+		if (Object.prototype.hasOwnProperty.call(db, key)) {
 			try {
 				// db[key] = "";
                 // let updatedDb = db;
@@ -158,7 +158,7 @@ class Jsoning {
 
 		let db = fs.readFileSync(resolve(__dirname, this.database), 'utf-8');
 		db = JSON.parse(db);
-		if (db[key]) {
+		if (Object.prototype.hasOwnProperty.call(db, key)) {
 			let data = db[key];
 			return data;
 		} else {
@@ -229,7 +229,7 @@ class Jsoning {
 
 		// see if value exists
 		let db = JSON.parse(fs.readFileSync(resolve(__dirname, this.database), 'utf-8'));
-		if (db[key]) {
+		if (Object.prototype.hasOwnProperty(db, key)) {
 			// key exists
 			let value = db[key];
 			if (typeof value !== 'number' || value === '') {
@@ -300,7 +300,7 @@ class Jsoning {
 		let db = fs.readFileSync(resolve(__dirname, this.database), 'utf-8');
 		db = JSON.parse(db);
 
-		if(db.hasOwnProperty(key)) {
+		if(Object.prototype.hasOwnProperty.call(db, key)) {
 			return true;
 		} else {
 			return false;
@@ -328,7 +328,7 @@ class Jsoning {
 		let db = fs.readFileSync(resolve(__dirname, this.database), 'utf-8');
 		db = JSON.parse(db);
 
-		if (db.hasOwnProperty(key)) {
+		if (Object.prototype.hasOwnProperty.call(db, key)) {
 			if (!Array.isArray(db[key])) {
                 console.log(db);
                 console.log(typeof db[key])


### PR DESCRIPTION
Using`Object.prototype.hasOwnProperty.call` instead of `<object>.hasOwnProperty` to to check if a property exist in an object

This also fixes a security bug "Prototype Pollution" using "hasOwnProperty" 
This vulnerability causes the addition or modification of an existing property that will exist on all objects and may lead to Denial of Service or Code Execution under specific circumstances.

example exploitation:
```js
await db.set("hasOwnProperty", "this will cause breakage to the application");
await db.has("somekey"); // Throws an error `db.hasOwnProperty is not a function`
```