### PR TITLE
jsoning was loaded as "database" not "db" in example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ View the full documentation [here](https://jsoning.js.org/).
 
 ```js
 let jsoning = require('jsoning');
-let database = new jsoning("database.json");
+let db = new jsoning("database.json");
 
 
 (async() => {


### PR DESCRIPTION
Basically, in the example, it used "db" to use jsoning, however, "db" wasn't defined. So I changed "let database" to "let db"